### PR TITLE
adds jshint Grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,11 +10,14 @@ module.exports = function(grunt) {
                     'surfnperf.min.js': 'surfnperf.js'
                 }
             }
+        },
+        jshint: {
+          all: 'surfnperf.js'
         }
     });
 
-
     grunt.loadNpmTasks('grunt-contrib-uglify');
+    grunt.loadNpmTasks('grunt-contrib-jshint');
 
-    grunt.registerTask('default', ['uglify']);
+    grunt.registerTask('default', ['jshint', 'uglify']);
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-uglify": "^0.4.0",
+    "grunt-contrib-jshint": "^0.10.0",
     "install": "^0.1.7",
     "karma": "^0.12.16",
     "karma-chrome-launcher": "^0.1.3",


### PR DESCRIPTION
jshint is included in the default Grunt tasks. Addresses Issue #11.
