### PR TITLE
adds 'build' and default grunt tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,11 +13,22 @@ module.exports = function(grunt) {
     },
     jshint: {
       all: 'surfnperf.js'
+    },
+    karma: {
+      unit: {
+        configFile: 'karma.conf.js'
+      },
+      continuous: {
+        configFile: 'karma.conf.js',
+        singleRun: true
+      }
     }
   });
 
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-karma');
 
-  grunt.registerTask('default', ['jshint', 'uglify']);
+  grunt.registerTask('default', ['jshint', 'karma:continuous']);
+  grunt.registerTask('build', ['jshint', 'karma:continuous', 'uglify']);
 };

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "karma-jasmine": "^0.1.5",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-requirejs": "^0.2.1",
+    "grunt-karma": "^0.8.3",
     "requirejs": "^2.1.11",
     "underscore": "^1.6.0"
   },


### PR DESCRIPTION
'grunt' runs jshint, karma tests, and exits.

'grunt build' runs jshint, tests, and minifies code.

Fixes Issue #14.
