### PR TITLE
fine-tunes Grunt tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - "0.10"
+before_install: npm install -g grunt-cli

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,15 +35,23 @@ module.exports = function(grunt) {
         configFile: 'karma.conf.js',
         singleRun: true
       }
+    },
+    watch: {
+      dev: {
+        files: ['surfnperf.js', 'spec/**/*.js'],
+        tasks: ['default']
+      }
     }
   });
 
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-jsbeautifier');
+  grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-karma');
 
   grunt.registerTask('default', ['jshint', 'karma:continuous']);
+  grunt.registerTask('dev', ['watch:dev']);
   grunt.registerTask('build', ['jshint', 'karma:continuous', 'uglify']);
   grunt.registerTask('precommit', ['jsbeautifier', 'build']);
 };

--- a/README.md
+++ b/README.md
@@ -67,16 +67,22 @@ Details in the [JavaScript API](https://github.com/Comcast/Surf-N-Perf/wiki/Java
 
 Tests are written in [Jasmine](http://jasmine.github.io/) and run with [Karma](http://karma-runner.github.io/)
 
-Install the dependencies to run the tests with:
+Install dependencies:
 
 ```bash
 $ npm install
 ```
 
-And then run the tests with:
+Run jshint and tests:
 
 ```bash
-$ npm run-script karma
+$ grunt
+```
+
+To continuously run JSHint and tests during development, run:
+
+```bash
+$ grunt dev
 ```
 
 By default, it will run the tests using [PhantomJS](http://phantomjs.org/). You can also run the tests in any browser by going to http://localhost:9876/

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.4.0",
+    "grunt-contrib-watch": "^0.6.1",
     "grunt-jsbeautifier": "^0.2.7",
     "grunt-karma": "^0.8.3",
     "install": "^0.1.7",
@@ -26,8 +27,7 @@
     "underscore": "^1.6.0"
   },
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start --single-run",
-    "karma": "./node_modules/karma/bin/karma start"
+    "test": "grunt"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- creates 'grunt dev' task to re-run jshint, tests, and code coverage
  analysis on file modification
- Travis CI now runs 'grunt', which also runs jshint
- updates README.md accordingly