### PR TITLE
fix(firstPaint): use paint timing api and remove deprecated chrome api

### DIFF
--- a/spec/surfnperf_spec.js
+++ b/spec/surfnperf_spec.js
@@ -1376,16 +1376,6 @@ define('spec/surfnperf_spec', [
     });
 
 
-    describe('#chromeLoadTimes', function() {
-      it('returns a reference to window.chrome.loadTimes() if the browser supports it, otherwise undefined', function() {
-        if(window.chrome && window.chrome.loadTimes) {
-          expect(SurfNPerf.chromeLoadTimes()).toEqual(window.chrome.loadTimes());
-        } else {
-          expect(SurfNPerf.chromeLoadTimes()).toEqual(undefined);
-        }
-      });
-    });
-
     describe('#msFirstPaint', function() {
       it('returns a reference to window.performance.timing.msFirstPaint if the browser supports it, otherwise undefined', function() {
         if(window.performance && window.performance.timing && window.performance.timing.msFirstPaint) {
@@ -1404,21 +1394,19 @@ define('spec/surfnperf_spec', [
         });
       });
 
-      describe('when the client is using Chrome', function() {
+      describe('when the client supports paint timing api (Chrome)', function() {
         it('returns the time to first paint relative to navigation start time', function() {
-          spyOn(SurfNPerf, 'chromeLoadTimes').andReturn({
-            firstPaintTime: 1388595601.000123
-          });
+          spyOn(SurfNPerf, '_supportsPaintAPI').andReturn(true);
           spyOn(SurfNPerf, 'msFirstPaint').andReturn(undefined);
 
-          expect(SurfNPerf.getFirstPaint()).toEqual(1000);
+          expect(SurfNPerf.getFirstPaint()).toNotEqual(null);
         });
       });
 
       describe('when the client is using IE/Edge', function() {
         it('returns the time to first paint relative to navigation start time', function() {
           spyOn(SurfNPerf, 'msFirstPaint').andReturn(1388595601005);
-          spyOn(SurfNPerf, 'chromeLoadTimes').andReturn(undefined);
+          spyOn(SurfNPerf, '_supportsPaintAPI').andReturn(false);
 
           expect(SurfNPerf.getFirstPaint()).toEqual(1005);
         });
@@ -1426,7 +1414,7 @@ define('spec/surfnperf_spec', [
 
       describe('when the client is using browser without Time to First Paint built in support', function() {
         it('returns null since the browser does not have built in support', function() {
-          spyOn(SurfNPerf, 'chromeLoadTimes').andReturn(undefined);
+          spyOn(SurfNPerf, '_supportsPaintAPI').andReturn(false);
           spyOn(SurfNPerf, 'msFirstPaint').andReturn(undefined);
 
           expect(SurfNPerf.getFirstPaint()).toEqual(null);

--- a/surfnperf.js
+++ b/surfnperf.js
@@ -426,8 +426,9 @@
    * @memberOf SurfNPerf
    */
   SNPProto.getFirstPaint = function(options) {
-    if(this.chromeLoadTimes()) {
-      return this._roundedDuration(this.getTimingMark('navigationStart', 'DOM'), this.chromeLoadTimes().firstPaintTime * 1000, options);
+    if (this._supportsPaintAPI()) {
+      var firstPaint = window.performance.getEntriesByName('first-paint')[0] || {};
+      return this._roundedDuration(this.getTimingMark('navigationStart', 'DOM'), firstPaint.startTime, options);
     } else if(this.msFirstPaint()) {
       return this._roundedDuration(this.getTimingMark('navigationStart', 'DOM'), this.msFirstPaint(), options);
     } else {
@@ -453,12 +454,8 @@
     }
   };
 
-  SNPProto.chromeLoadTimes = function() {
-    if(window.chrome && window.chrome.loadTimes) {
-      return window.chrome.loadTimes();
-    } else {
-      return undefined;
-    }
+  SNPProto._supportsPaintAPI = function() {
+    return window.performance && window.performance.getEntriesByName && 'PerformancePaintTiming' in window;
   };
 
   SNPProto.msFirstPaint = function() {


### PR DESCRIPTION
## What
  - Remove Chrome loadTimes.
  - Add replacement for any browser supporting Performance Paint API

## Why
  - Deprecated API in Chrome announced

Fixes #52 (removed the old way since its also pretty old and Chrome updates regularly)