### PR TITLE
Upgrading rake

### DIFF
--- a/gem/Gemfile
+++ b/gem/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gemspec
-gem 'rake', '10.0.1'
+gem 'rake', '12.3.3'


### PR DESCRIPTION
sec-vuln recommendation

rake build still works with:
- rvm 1.29.10
- ruby 2.7.0
- bundler 1.14.3