### PR TITLE
Version 2.0.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+<a name="2.0.0"></a>
+### 2.0.0
+
+#### Breaking Updates
+
+* Removes deprecated `chromeLoadTimes`
+
+#### Features
+
+* Using the [Paint Timing API](https://developer.mozilla.org/en-US/docs/Web/API/PerformancePaintTiming) for First Paint data
+
 <a name="1.6.0"></a>
 ### 1.6.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surfnperf",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "surfnperf",
-      "version": "1.6.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surfnperf",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "description": "Micro-library for gathering frontend web page performance data",
   "main": "surfnperf.min",
   "engines": {


### PR DESCRIPTION
#### Breaking Updates

* Removes deprecated `chromeLoadTimes` via https://github.com/Comcast/Surf-N-Perf/commit/155940b0b8e8b9c04c798641b24405b1710751b6

#### Features

* Using the [Paint Timing API](https://developer.mozilla.org/en-US/docs/Web/API/PerformancePaintTiming) for First Paint data